### PR TITLE
New data model & semantic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "paf-mvp-operator-express",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "paf-mvp-operator-express",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "dependencies": {
         "@types/cors": "^2.8.12",
@@ -14,7 +14,7 @@
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
         "express": "^4.17.1",
-        "paf-mvp-core-js": "criteo/paf-mvp-core-js#53258982e4df8c7c4db78660147792d79f7bdf58",
+        "paf-mvp-core-js": "criteo/paf-mvp-core-js#semver:0.1.1",
         "tld-extract": "^2.0.1",
         "uuid": "^8.3.2"
       },
@@ -465,9 +465,8 @@
     },
     "node_modules/paf-mvp-core-js": {
       "name": "paf-mvp-core",
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/criteo/paf-mvp-core-js.git#53258982e4df8c7c4db78660147792d79f7bdf58",
-      "integrity": "sha512-YUnhbY7YxEku0XgqtRRRX3PnF8I+hhWHL56NEYQMxPwRZcelPzo47nha1yVaBwKHpYbQa0hlJJfIuJXm670m4w==",
+      "version": "0.1.1",
+      "resolved": "git+ssh://git@github.com/criteo/paf-mvp-core-js.git#f39fd2bb8fae37dfb116393267e3d923e5a2269c",
       "license": "ISC",
       "dependencies": {
         "ec-key": "^0.0.4",
@@ -987,9 +986,8 @@
       }
     },
     "paf-mvp-core-js": {
-      "version": "git+ssh://git@github.com/criteo/paf-mvp-core-js.git#53258982e4df8c7c4db78660147792d79f7bdf58",
-      "integrity": "sha512-YUnhbY7YxEku0XgqtRRRX3PnF8I+hhWHL56NEYQMxPwRZcelPzo47nha1yVaBwKHpYbQa0hlJJfIuJXm670m4w==",
-      "from": "paf-mvp-core-js@criteo/paf-mvp-core-js#53258982e4df8c7c4db78660147792d79f7bdf58",
+      "version": "git+ssh://git@github.com/criteo/paf-mvp-core-js.git#f39fd2bb8fae37dfb116393267e3d923e5a2269c",
+      "from": "paf-mvp-core-js@criteo/paf-mvp-core-js#semver:0.1.1",
       "requires": {
         "ec-key": "^0.0.4",
         "ecdsa-secp256r1": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paf-mvp-operator-express",
-  "version": "0.1.1",
+  "version": "0.1.4",
   "description": "Prebid Addressability Framework (PAF) Operator: ExpressJS implementation",
   "main": "index.js",
   "type": "commonjs",
@@ -25,7 +25,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "express": "^4.17.1",
-    "paf-mvp-core-js": "criteo/paf-mvp-core-js#semver:0.1.1",
+    "paf-mvp-core-js": "criteo/paf-mvp-core-js#semver:0.1.4",
     "tld-extract": "^2.0.1",
     "uuid": "^8.3.2"
   },

--- a/src/operator-api.ts
+++ b/src/operator-api.ts
@@ -217,7 +217,7 @@ export class OperatorApi {
 
     signId(value: string, timestampInSec = getTimeStampInSec()): Identifier {
         const unsignedId: UnsignedData<Identifier> = {
-            version: 0,
+            version: "0.1",
             type: 'paf_browser_id',
             value,
             source: {

--- a/src/operator-api.ts
+++ b/src/operator-api.ts
@@ -10,7 +10,9 @@ import {
     IdsAndOptionalPreferences,
     PostIdsPrefsRequest,
     PostIdsPrefsResponse,
-    Preferences
+    Preferences,
+    Get3PcResponse,
+    Error as PAFError
 } from "paf-mvp-core-js/dist/model/generated-model";
 import {isEmptyListOfIds, UnsignedData, UnsignedMessage} from "paf-mvp-core-js/dist/model/model";
 import {
@@ -189,6 +191,9 @@ export const addOperatorApi = (app: Express, operatorHost: string, privateKey: s
 
         const isOk = testCookieValue?.length > 0;
 
+        // FIXME use operatorAPI.build3PC
+        // FIXME return 404 if not supported
+
         res.send(JSON.stringify(isOk))
     });
 
@@ -310,5 +315,11 @@ export class OperatorApi {
                 signature: this.idSigner.sign(this.ecdsaKey, unsignedId)
             }
         };
+    }
+
+    build3PC(supported: boolean): Get3PcResponse | PAFError {
+        return supported
+            ? {"3pc": true}
+            : {message: "3PC not supported"}
     }
 }

--- a/src/operator-api.ts
+++ b/src/operator-api.ts
@@ -236,7 +236,7 @@ export class OperatorApi {
     buildGetIdsPrefsResponse(
         receiver: string,
         {identifiers, preferences}: IdsAndOptionalPreferences,
-        timestamp = new Date().getTime()
+        timestampInSec = new Date().getTime() / 1000
     ): GetIdsPrefsResponse {
         const data: UnsignedMessage<GetIdsPrefsResponse> = {
             body: {
@@ -245,7 +245,7 @@ export class OperatorApi {
             },
             sender: this.host,
             receiver,
-            timestamp
+            timestamp: timestampInSec
         };
 
         return {
@@ -257,7 +257,7 @@ export class OperatorApi {
     buildPostIdsPrefsResponse(
         receiver: string,
         {identifiers, preferences}: IdsAndOptionalPreferences,
-        timestamp = new Date().getTime()
+        timestampInSec = new Date().getTime() / 1000
     ): PostIdsPrefsResponse {
         const data: UnsignedMessage<PostIdsPrefsResponse> = {
             body: {
@@ -266,7 +266,7 @@ export class OperatorApi {
             },
             sender: this.host,
             receiver,
-            timestamp
+            timestamp: timestampInSec
         };
 
         return {
@@ -275,14 +275,14 @@ export class OperatorApi {
         }
     }
 
-    buildGetNewIdResponse(receiver: string, newId = this.generateNewId(), timestamp = new Date().getTime()): GetNewIdResponse {
+    buildGetNewIdResponse(receiver: string, newId = this.generateNewId(), timestampInSec = new Date().getTime() / 1000): GetNewIdResponse {
         const data: UnsignedMessage<GetNewIdResponse> = {
             body: {
                 identifiers: [newId],
             },
             sender: this.host,
             receiver,
-            timestamp
+            timestamp: timestampInSec
         };
 
         return {
@@ -291,14 +291,14 @@ export class OperatorApi {
         }
     }
 
-    signId(value: string, timestamp = new Date().getTime()): Identifier {
+    signId(value: string, timestampInSec = new Date().getTime() / 1000): Identifier {
         const unsignedId: UnsignedData<Identifier> = {
             version: 0,
             type: 'paf_browser_id',
             value,
             source: {
                 domain: this.host,
-                timestamp
+                timestamp: timestampInSec
             }
         };
         const {source, ...rest} = unsignedId

--- a/src/operator-api.ts
+++ b/src/operator-api.ts
@@ -15,6 +15,7 @@ import {
     Error as PAFError
 } from "paf-mvp-core-js/dist/model/generated-model";
 import {isEmptyListOfIds, UnsignedData, UnsignedMessage} from "paf-mvp-core-js/dist/model/model";
+import {getTimeStampInSec} from "paf-mvp-core-js/dist/timestamp";
 import {
     GetIdsPrefsRequestSigner,
     GetIdsPrefsResponseSigner,
@@ -111,6 +112,7 @@ export const addOperatorApi = (app: Express, operatorHost: string, privateKey: s
 
         const redirectUrl = getReturnUrl(req, res)
         if (redirectUrl) {
+            // FIXME use GetIdsPrefsResponseBuilder
             const response = operatorApi.buildGetIdsPrefsResponse(message.sender, {
                 identifiers: [existingId],
                 preferences
@@ -175,6 +177,7 @@ export const addOperatorApi = (app: Express, operatorHost: string, privateKey: s
         const existingId = getExistingId(req)
         const preferences = getExistingPrefs(req)
 
+        // FIXME use GetIdsPrefsResponseBuilder
         const response = operatorApi.buildGetIdsPrefsResponse(message.sender, {identifiers: [existingId], preferences})
 
         res.send(JSON.stringify(response))
@@ -241,7 +244,7 @@ export class OperatorApi {
     buildGetIdsPrefsResponse(
         receiver: string,
         {identifiers, preferences}: IdsAndOptionalPreferences,
-        timestampInSec = new Date().getTime() / 1000
+        timestampInSec = getTimeStampInSec()
     ): GetIdsPrefsResponse {
         const data: UnsignedMessage<GetIdsPrefsResponse> = {
             body: {
@@ -262,7 +265,7 @@ export class OperatorApi {
     buildPostIdsPrefsResponse(
         receiver: string,
         {identifiers, preferences}: IdsAndOptionalPreferences,
-        timestampInSec = new Date().getTime() / 1000
+        timestampInSec = getTimeStampInSec()
     ): PostIdsPrefsResponse {
         const data: UnsignedMessage<PostIdsPrefsResponse> = {
             body: {
@@ -280,7 +283,8 @@ export class OperatorApi {
         }
     }
 
-    buildGetNewIdResponse(receiver: string, newId = this.generateNewId(), timestampInSec = new Date().getTime() / 1000): GetNewIdResponse {
+    // FIXME use GetNewIdResponseBuilder
+    buildGetNewIdResponse(receiver: string, newId = this.generateNewId(), timestampInSec = getTimeStampInSec()): GetNewIdResponse {
         const data: UnsignedMessage<GetNewIdResponse> = {
             body: {
                 identifiers: [newId],
@@ -296,7 +300,7 @@ export class OperatorApi {
         }
     }
 
-    signId(value: string, timestampInSec = new Date().getTime() / 1000): Identifier {
+    signId(value: string, timestampInSec = getTimeStampInSec()): Identifier {
         const unsignedId: UnsignedData<Identifier> = {
             version: 0,
             type: 'paf_browser_id',


### PR DESCRIPTION
- use new format for query strings (use a single `paf` parameter)
- all messages renamed from `Id` to `Ids` (because it's _a list_ of identifiers)
- renamed all cookies
- use new semantic for REST & redirect endpoints
- use Request and Response _builders_
- introduce error handling (more to come)